### PR TITLE
Add service-level.yaml — Honey Badger ownership

### DIFF
--- a/service-level.yaml
+++ b/service-level.yaml
@@ -1,0 +1,6 @@
+services:
+  - name: yw-geo_ip
+    owner: honey-badger
+    language: ruby
+    nonServiceType: library
+    description: "Retreive the geolocation of an IP address based on the ipinfodb.com webservice"


### PR DESCRIPTION
Declares ownership and classification for this repository in its `service-level.yaml`, so it appears in the internal service catalog (https://employees.vendasta-internal.com/services) under the **Honey Badger** team instead of the "missing service-level.yaml" list.

This repo has no deployed service, so it is classified with `nonServiceType: library`.

Part of CTO-45: adding service-level.yaml to all yeti_*/yw-* repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)